### PR TITLE
Add Gauge metric type with recordGauge public API

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ export {
     initializeTelemetry,
     changeSignalConnection,
     recordHistogram,
+    recordGauge,
     decrementCounter,
     incrementCounter,
     getTrace,

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -63,8 +63,11 @@ export class GaugeArgs {
 
 export class AnacondaMetrics extends AnacondaCommon {
     private reader: PeriodicExportingMetricReader | undefined;
+    /** @internal Exposed for test assertions only; not part of the public API. */
     mapOfCounters: Record<string, [UpDownCounter | Counter, boolean]> = {};
+    /** @internal Exposed for test assertions only; not part of the public API. */
     mapOfHistograms: Record<string, Histogram> = {};
+    /** @internal Exposed for test assertions only; not part of the public API. */
     mapOfGauges: Record<string, Gauge> = {};
     meterProvider: MeterProvider | undefined = undefined
     meter: Meter | null = null;

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -26,6 +26,7 @@ import type {
   UpDownCounter,
   Counter,
   Histogram,
+  Gauge,
 } from '@opentelemetry/api';
 
 import type {
@@ -54,10 +55,17 @@ export class HistogramArgs {
     attributes?: AttrMap = {};
 }
 
+export class GaugeArgs {
+    name: string = "";
+    value: number = 0;
+    attributes?: AttrMap = {};
+}
+
 export class AnacondaMetrics extends AnacondaCommon {
     private reader: PeriodicExportingMetricReader | undefined;
     mapOfCounters: Record<string, [UpDownCounter | Counter, boolean]> = {};
     mapOfHistograms: Record<string, Histogram> = {};
+    mapOfGauges: Record<string, Gauge> = {};
     meterProvider: MeterProvider | undefined = undefined
     meter: Meter | null = null;
     parentExporter: MetricExporterShim | undefined
@@ -115,6 +123,20 @@ export class AnacondaMetrics extends AnacondaCommon {
         }
         var histogram = this.getHistogram(args.name)
         histogram.record(args.value!, this.makeEventAttributes(args.attributes));
+        return true
+    }
+
+    recordGauge(args: GaugeArgs): boolean {
+        if (!this.meter) {
+            this._warn("Meter is not initialized properly. Ensure that the AnacondaMetrics instance is properly set up.")
+            return false
+        }
+        if (!this.isValidName(args.name)) {
+            this._warn(`Metric name '${args.name}' is not a valid name (^[A-Za-z][A-Za-z_0-9]+$).`)
+            return false
+        }
+        var gauge = this.getGauge(args.name)
+        gauge.record(args.value, this.makeEventAttributes(args.attributes));
         return true
     }
 
@@ -250,6 +272,15 @@ export class AnacondaMetrics extends AnacondaCommon {
         var histogram: Histogram = this.meter!.createHistogram(metricName)
         this.mapOfHistograms[metricName] = histogram
         return histogram
+    }
+
+    private getGauge(metricName: string): Gauge {
+        if (metricName in this.mapOfGauges) {
+            return this.mapOfGauges[metricName]
+        }
+        var gauge: Gauge = this.meter!.createGauge(metricName)
+        this.mapOfGauges[metricName] = gauge
+        return gauge
     }
 }
 

--- a/src/signals.ts
+++ b/src/signals.ts
@@ -3,7 +3,7 @@
 
 import { Configuration } from './config.js';
 import { ResourceAttributes } from './attributes.js';
-import { AnacondaMetrics, CounterArgs, HistogramArgs } from './metrics.js';
+import { AnacondaMetrics, CounterArgs, HistogramArgs, GaugeArgs } from './metrics.js';
 import { AnacondaTrace } from './traces.js';
 import { AnacondaLogging, type ATelLogger, EventArgs } from './logging.js';
 
@@ -135,6 +135,35 @@ export function recordHistogram(args: HistogramArgs): boolean {
         return false
     }
     return __metrics.recordHistogram(args); // Call the recordHistogram method on the AnacondaMetrics instance
+}
+
+/**
+ * Records an instantaneous value in a gauge metric with optional attributes.
+ *
+ * @param args - An argument list object where the `name` field is required.
+ *
+ * The args is an object defined by (in any order):
+ * ```
+ * {
+ *   name: string = "";  Required; Not supplying a name will result in no value being recorded.
+ *   value: number = 0;  Required; This field will be recorded as the instantaneous value.
+ *   attributes?: AttrMap = {}; Optional; Attributes for the gauge metric.
+ * }
+ * ```
+ *
+ * @returns `true` if the gauge was recorded successfully, `false` if metrics are not initialized.
+ *
+ * @example
+ * ```typescript
+ * recordGauge({name: "cpu.usage", value: 72.5, attributes: { "host": "node-1" }})
+ * ```
+ */
+export function recordGauge(args: GaugeArgs): boolean {
+    if (!__metrics) {
+        console.warn("*** WARNING: Metrics not initialized. Call initializeTelemetry first.")
+        return false
+    }
+    return __metrics.recordGauge(args);
 }
 
 /**

--- a/tests/unit/metrics.test.ts
+++ b/tests/unit/metrics.test.ts
@@ -8,7 +8,7 @@ import { jest, expect, beforeEach } from '@jest/globals';
 
 import { Configuration, InternalConfiguration } from '../../src/config'
 import { ResourceAttributes, InternalResourceAttributes } from '../../src/attributes'
-import { AnacondaMetrics, CounterArgs, HistogramArgs, NoopMetricExporter } from '../../src/metrics'
+import { AnacondaMetrics, CounterArgs, HistogramArgs, GaugeArgs, NoopMetricExporter } from '../../src/metrics'
 
 jest.mock('@opentelemetry/sdk-metrics')
 jest.mock('@opentelemetry/exporter-metrics-otlp-http')
@@ -23,6 +23,7 @@ import type {
   Counter,
   UpDownCounter,
   Histogram,
+  Gauge,
   ObservableGauge,
   ObservableCounter,
   ObservableUpDownCounter,
@@ -32,6 +33,7 @@ import type {
 const makeCounter = () => ({ add: jest.fn() }) as unknown as jest.Mocked<Counter>;
 const makeUpDownCounter = () => ({ add: jest.fn() }) as unknown as jest.Mocked<UpDownCounter>;
 const makeHistogram = () => ({ record: jest.fn() }) as unknown as jest.Mocked<Histogram>;
+const makeGauge = () => ({ record: jest.fn() }) as unknown as jest.Mocked<Gauge>;
 
 const makeObsGauge = () =>
   ({ addCallback: jest.fn(), removeCallback: jest.fn() }) as unknown as jest.Mocked<ObservableGauge>;
@@ -58,9 +60,8 @@ export const mockedMeter: jest.Mocked<Meter> = (() => {
   m.addBatchObservableCallback = jest.fn();
   m.removeBatchObservableCallback = jest.fn();
 
-  // If your code calls a legacy/non-standard API (e.g., createGauge),
-  // attach it AFTER casting so it doesn't fight the Meter type:
-  // m.createGauge = jest.fn(() => ({ record: jest.fn() }));
+  // Gauge is not part of the Meter interface type yet in some versions, attach after cast
+  (m as any).createGauge = jest.fn(() => makeGauge());
 
   return m as jest.Mocked<Meter>;
 })();
@@ -124,6 +125,16 @@ test("verify incrementCounter and decrementCounter", () => {
     expect(metrics.incrementCounter({name: "name2", forceUpDownCounter: true, by: 2, attributes: {"reason": "test"}})).toBe(false)
 })
 
+test("verify recordGauge", () => {
+    expect(metrics.recordGauge({name: "gauge1", value: 42.5, attributes: {"reason": "test"}})).toBe(true)
+    expect(Object.keys(metrics.mapOfGauges).length).toBe(1)
+    expect(metrics.recordGauge({name: "gauge2", value: 99.9, attributes: {"reason": "test"}})).toBe(true)
+    expect(metrics.recordGauge({name: "gauge2", value: 10.0, attributes: {"reason": "test"}})).toBe(true)
+    expect(Object.keys(metrics.mapOfGauges).length).toBe(2)
+    metrics.meter = null
+    expect(metrics.recordGauge({name: "gauge3", value: 0, attributes: {"reason": "test"}})).toBe(false)
+})
+
 test("verify non-console implementation for setup and variations", () => {
     var counter = 0
     for (let authToken of [undefined, "auth_token"]) {
@@ -175,11 +186,13 @@ test("check for invalid names", () => {
     expect(metrics.decrementCounter({name: "#name", by: 1})).toBe(false)
     expect(metrics.incrementCounter({name: "name#", forceUpDownCounter: false, by: 1})).toBe(false)
     expect(metrics.recordHistogram({name: "#name#", value: 42})).toBe(false)
+    expect(metrics.recordGauge({name: "#gauge#", value: 1.0})).toBe(false)
 })
 
 test("dummy tests for argument objects (would lower coverage but could be deleteed)", () => {
     const counter = new CounterArgs()
     const histogram = new HistogramArgs()
+    const gauge = new GaugeArgs()
 })
 
 test("Test bad changeConnection URL", async () => {

--- a/tests/unit/signals.test.ts
+++ b/tests/unit/signals.test.ts
@@ -8,6 +8,7 @@ import {
     initializeTelemetry,
     changeSignalConnection,
     recordHistogram,
+    recordGauge,
     decrementCounter,
     incrementCounter,
     getTrace,
@@ -125,6 +126,24 @@ test("recordHistogram with metrics initialized", () => {
 
 test("recordHistogram without metrics initialized", () => {
     const result = recordHistogram({name: "test_metric", value: 42})
+
+    expect(result).toBe(false)
+    expect(console.warn).toHaveBeenCalledWith("*** WARNING: Metrics not initialized. Call initializeTelemetry first.")
+})
+
+test("recordGauge with metrics initialized", () => {
+    const config = new Configuration().setUseConsoleOutput(true)
+    const attributes = new ResourceAttributes("test_service", "0.0.1")
+
+    initializeTelemetry(config, attributes, ["metrics"])
+
+    const result = recordGauge({name: "testGauge", value: 72.5, attributes: { key: "value" }})
+
+    expect(result).toBe(true)
+})
+
+test("recordGauge without metrics initialized", () => {
+    const result = recordGauge({name: "test_gauge", value: 42.0})
 
     expect(result).toBe(false)
     expect(console.warn).toHaveBeenCalledWith("*** WARNING: Metrics not initialized. Call initializeTelemetry first.")


### PR DESCRIPTION
Implements OTel Gauge instrument (meter.createGauge) following the same lazy-instantiation registry pattern used by Histogram and Counter. Exports GaugeArgs and recordGauge through the public API surface.